### PR TITLE
Bump version add debugmask, add camdisable

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,10 @@
 VDR Plugin 'mcli' Revision History
 ----------------------------------
+2021-01-24
+- pbiering add debug mask option (--debug-mask) (see mcli.h)
+- pbiering fix a bunch of debug messages and turn them to be controllable by --debug-mask
+- pbiering add cam-disable mode which avoid tuning to channel which requires CAM in case CAMs are generally not in use in the system (--cam-disable)
+
 2020-12-15
 - pbiering add support for DeviceType (supported since 1.7.28)
 - pbiering add tuner-max option to limit amount of tuners in skins

--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,9 @@
 VDR Plugin 'mcli' Revision History
 ----------------------------------
+2021-01-25
+- pbiering cMcliDevice::SetPid: LOCK_THREAD deactivated because resulting in deadlock with osdteletext and zapping
+- pbiering honor cam-disable earlier in cMcliDevice::SetChannelDevice
+
 2021-01-24
 - pbiering add debug mask option (--debug-mask) (see mcli.h)
 - pbiering fix a bunch of debug messages and turn them to be controllable by --debug-mask

--- a/README
+++ b/README
@@ -118,5 +118,6 @@ END
 		TUNE_EXTRA    0x02
 		TUNE          0x04
 		RESOURCES     0x08
-		FILTER        0x10
+		PIDS_ADD_DEL  0x10
 		TUNE_PC       0x40    // ProvideChannel
+		FILTER        0x80

--- a/README
+++ b/README
@@ -71,12 +71,12 @@ vdr-1.6.0-intcamdevices.patch (enables selection of encrypted channels
 
 On newer Linux systems allow vdr to open raw sockets:
 
-setcap cap_net_raw=pe /usr/sbin/vdr 
+setcap cap_net_raw=pe /usr/sbin/vdr
 
 
 for systemd:
 
-cat <<END >/etc/systemd/system/vdr.service.d/override.conf 
+cat <<END >/etc/systemd/system/vdr.service.d/override.conf
 [Service]
 AmbientCapabilities=CAP_NET_RAW
 END
@@ -103,7 +103,7 @@ END
 
 --sock-path <path>
 	path of socket directory, default: API_SOCK_NAMESPACE
- 
+
 --cam-disable (NEW)
 	reject tuning to channels which requiring CAM
 

--- a/README
+++ b/README
@@ -4,12 +4,17 @@ produced by the NetCeiver-hardware.
 Project's homepage:
 http://www.baycom.de/hardware/netceiver/
 
-Latest version available via SVN at:
-https://svn.baycom.de/repos/vdr-mcli-plugin/
+Latest version available via GIT at:
+https://github.com/vdr-projects/vdr-plugin-mcli
 
 The vdr-plugin, mcli-library and associated tools&drivers
 except netcv2dvbip are
 Copyright (C) 2007-2010 by BayCom GmbH <info@baycom.de>
+
+Extensions by contributors
+Copyright (C) 2020-2021 by Peter Bieringer <pb@bieringer.de>
+
+TODO: add more (-> git changelog)
 
 netcv2dvbip is 
 Copyright (C) 2010 by Christian Cier-Zniewski <c.cier@gmx.de>
@@ -50,11 +55,68 @@ You should have received a copy of the GNU General Public License along with
 this program; if not, write to the Free Software Foundation, Inc., 51
 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-
+**** TO BE CHECKED ****
 To properly integrate the mcli plugin into your VDR please apply these two
 patches:
 
 vdr-1.6.0-altmenuaction.patch (allows CAM messages to be displayed)
 vdr-1.6.0-intcamdevices.patch (enables selection of encrypted channels
                                without local CI stack).
+
+**** Reviewed version ****
+
+- Support at least vdr >= 2.4.4
+
+== Potential requirements ==
+
+On newer Linux systems allow vdr to open raw sockets:
+
+setcap cap_net_raw=pe /usr/sbin/vdr 
+
+
+for systemd:
+
+cat <<END >/etc/systemd/system/vdr.service.d/override.conf 
+[Service]
+AmbientCapabilities=CAP_NET_RAW
+END
+
+
+== Plugin options ==
+
+--ifname <interface>
+	network interface of the multicast client
+		the interface where the Netceiver boxes are also connected
+
+--port <port>
+	used network port (default: 23000)
+
+--dvb-s <num>
+--dvb-c <num>
+--dvb-t <num>
+--atsc <num>
+--dvb-s2 <num>
+	limit number of devices (default: 8)
+
+--mld-reporter-disable
+	disable mld reporter
+
+--sock-path <path>
+	path of socket directory, default: API_SOCK_NAMESPACE
  
+--cam-disable (NEW)
+	reject tuning to channels which requiring CAM
+
+--tuner-max <num> (NEW)
+	limit maximum number of tuners to <num>
+		avoid that LCARS skin shows 8 tuners in a 3 tuner system
+
+ --debugmask <mask> (NEW)
+	<mask> can be hexadecimal (0x..) or decimal
+	conditionally enable debug messages
+		PIDS          0x01
+		TUNE_EXTRA    0x02
+		TUNE          0x04
+		RESOURCES     0x08
+		FILTER        0x10
+		TUNE_PC       0x40    // ProvideChannel

--- a/device.c
+++ b/device.c
@@ -88,7 +88,9 @@ cMcliDevice::cMcliDevice (void)
 	InitMcli ();
 
 #ifdef DEBUG_RESOURCES
+	DEBUG_MASK(DEBUG_BIT_RESOURCES,
 	dsyslog ("Mcli::%s: DVB got device number %d\n", __FUNCTION__, CardIndex () + 1);
+	)
 #endif
 
 }
@@ -98,7 +100,9 @@ cMcliDevice::~cMcliDevice ()
 	LOCK_THREAD;
 	StopSectionHandler ();
 #ifdef DEBUG_RESOURCES
+	DEBUG_MASK(DEBUG_BIT_RESOURCES,
 	dsyslog ("Mcli::%s: DVB %d gets destructed\n", __FUNCTION__, CardIndex () + 1);
+	)
 #endif
 	Cancel (0);
 	m_locked.Broadcast ();
@@ -318,7 +322,7 @@ bool cMcliDevice::ProvidesSource (int Source) const
 		}
 	} 
 #ifdef DEBUG_TUNE_EXTRA
-	DEBUG_MASK(DEBUG_BIT_TUNE-EXTRA,
+	DEBUG_MASK(DEBUG_BIT_TUNE_EXTRA,
 	dsyslog ("Mcli::%s: DVB:%d Type:%d Pos:%d -> %d\n", __FUNCTION__, CardIndex () + 1, type, pos, ret);
 	)
 #endif
@@ -443,14 +447,14 @@ bool cMcliDevice::ProvidesChannel (const cChannel * Channel, int Priority, bool 
 		return false;
 	}
 	if(ProvidesTransponder(Channel)) {
-#ifdef DEBUG_TUNE
+#ifdef DEBUG_TUNE_PC
 		DEBUG_MASK(DEBUG_BIT_TUNE_PC,
 		dsyslog ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel:%s * 'ProvidesTransponder(Channel)' is True\n", CardIndex () + 1, Channel->Name ());
 		)
 #endif
 		result = hasPriority;
 
-#ifdef DEBUG_TUNE
+#ifdef DEBUG_TUNE_PC
 		DEBUG_MASK(DEBUG_BIT_TUNE_PC,
 		dsyslog ("Mcli::ProvidesChannel: DEBUG result %d hasPriority %d\n", result, hasPriority);
 		)
@@ -458,7 +462,7 @@ bool cMcliDevice::ProvidesChannel (const cChannel * Channel, int Priority, bool 
 
 		if (Priority >= 0 && Receiving (true))
 		{
-#ifdef DEBUG_TUNE
+#ifdef DEBUG_TUNE_PC
 			DEBUG_MASK(DEBUG_BIT_TUNE_PC,
 	                dsyslog ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel:%s * 'Priority >= 0 && Receiving (true)' is True\n", CardIndex () + 1, Channel->Name ());
 			)
@@ -466,7 +470,7 @@ bool cMcliDevice::ProvidesChannel (const cChannel * Channel, int Priority, bool 
 
 			if (!IsTunedToTransponder(Channel)) {
 				needsDetachReceivers = true;
-#ifdef DEBUG_TUNE
+#ifdef DEBUG_TUNE_PC
 				DEBUG_MASK(DEBUG_BIT_TUNE_PC,
 	                        dsyslog ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel:%s * '!IsTunedToTransponder(Channel)' is True\n", CardIndex () + 1, Channel->Name ());
 				)
@@ -474,7 +478,7 @@ bool cMcliDevice::ProvidesChannel (const cChannel * Channel, int Priority, bool 
 
 			} else {
 				result = true;
-#ifdef DEBUG_TUNE
+#ifdef DEBUG_TUNE_PC
 				DEBUG_MASK(DEBUG_BIT_TUNE_PC,
                                 dsyslog ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel:%s * '!IsTunedToTransponder(Channel)' is False * result = true ***** OK\n", CardIndex () + 1, Channel->Name ());
 				)
@@ -482,14 +486,14 @@ bool cMcliDevice::ProvidesChannel (const cChannel * Channel, int Priority, bool 
 			}
 
 		} else {
-#ifdef DEBUG_TUNE
+#ifdef DEBUG_TUNE_PC
 			DEBUG_MASK(DEBUG_BIT_TUNE_PC,
                         dsyslog ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel:%s * 'Priority >= 0 && Receiving (true)' is False\n", CardIndex () + 1, Channel->Name ());
 			)
 #endif
 		}
 	} else {
-#ifdef DEBUG_TUNE
+#ifdef DEBUG_TUNE_PC
 		DEBUG_MASK(DEBUG_BIT_TUNE_PC,
                 dsyslog ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel:%s * 'ProvidesTransponder(Channel)' is False\n", CardIndex () + 1, Channel->Name ());
 		)
@@ -813,10 +817,12 @@ bool cMcliDevice::SetChannelDevice (const cChannel * Channel, bool LiveView)
 //		printf("add dummy pid 0 @ %p\n", this);
 	}
 #ifdef DEBUG_PIDS
+	DEBUG_MASK(DEBUG_BIT_PIDS,
 	dsyslog ("Mcli::%s: %p Pidsnum:%d m_pidsnum:%d\n", __FUNCTION__, m_r, m_mcpidsnum, m_pidsnum);
 	for (int i = 0; i < m_mcpidsnum; i++) {
 		dsyslog ("Pid:%d\n", m_pids[i].pid);
 	}
+	)
 #endif
 	m_ten.lastseen=m_last=time(NULL);
 	m_showtuning = true;
@@ -887,10 +893,12 @@ bool cMcliDevice::SetPid (cPidHandle * Handle, int Type, bool On)
 	}
 	m_mcpidsnum = recv_pids_get (m_r, m_pids);
 #ifdef DEBUG_PIDS
+	DEBUG_MASK(DEBUG_BIT_PIDS,
 	dsyslog ("Mcli::%s: %p Pidsnum:%d m_pidsnum:%d m_filternum:%d\n", __FUNCTION__, m_r, m_mcpidsnum, m_pidsnum, m_filternum);
 	for (int i = 0; i < m_mcpidsnum; i++) {
 		dsyslog ("Pid:%d\n", m_pids[i].pid);
 	}
+	)
 #endif
 	m_last=time(NULL);
 	return true;
@@ -980,10 +988,12 @@ int cMcliDevice::OpenFilter (u_short Pid, u_char Tid, u_char Mask)
 	recv_pid_add (m_r, &pi);
 	m_mcpidsnum = recv_pids_get (m_r, m_pids);
 #ifdef DEBUG_PIDS
+	DEBUG_MASK(DEBUG_BIT_PIDS,
 	dsyslog ("Mcli::%s: %p Pidsnum:%d m_pidsnum:%d\n", __FUNCTION__, m_r, m_mcpidsnum, m_pidsnum);
 	for (int i = 0; i < m_mcpidsnum; i++) {
 		dsyslog ("Pid:%d\n", m_pids[i].pid);
 	}
+	)
 #endif
 	return m_filters->OpenFilter (Pid, Tid, Mask);
 }

--- a/device.c
+++ b/device.c
@@ -884,10 +884,18 @@ bool cMcliDevice::SetPid (cPidHandle * Handle, int Type, bool On)
 			else if(Prio == -1) // Live
 				pi.priority |= 1<<2;
 #endif
-//			printf ("Add Pid:%d Sid:%d Type:%d Prio:%d %d\n", pi.pid, pi.id, Type, pi.priority, m_chan.Ca(0));
+#ifdef DEBUG_PIDS_ADD_DEL
+			DEBUG_MASK(DEBUG_BIT_PIDS_ADD_DEL,
+			dsyslog ("Mcli::%s: DVB:%d Add Pid:%d Sid:%d Type:%d Prio:%d %d", __FUNCTION__, CardIndex () + 1, pi.pid, pi.id, Type, pi.priority, m_chan.Ca(0));
+			)
+#endif
 			recv_pid_add (m_r, &pi);
 		} else {
-//                     	printf ("Del Pid:%d\n", Handle->pid);
+#ifdef DEBUG_PIDS_ADD_DEL
+			DEBUG_MASK(DEBUG_BIT_PIDS_ADD_DEL,
+			dsyslog ("Mcli::%s: DVB:%d Del Pid:%d\n", __FUNCTION__, CardIndex () + 1, Handle->pid);
+			)
+#endif
 			recv_pid_del (m_r, Handle->pid);
 		}
 	}

--- a/device.c
+++ b/device.c
@@ -208,14 +208,18 @@ bool cMcliDevice::SetTempDisable (bool now)
 		if(GetCaEnable()) {
 			SetCaEnable(false);
 #ifdef DEBUG_TUNE
+			DEBUG_MASK(DEBUG_BIT_TUNE,
 			dsyslog("Mcli::%s: Releasing CAM on device %d (%s) (disable, %d)\n", __FUNCTION__, CardIndex()+1, m_chan.Name(), now);
+			)
 #endif
 			m_mcli->CAMFree(m_camref);
 			m_camref = NULL;
 		}
 		if(m_tunerref) {
 #ifdef DEBUG_TUNE
+			DEBUG_MASK(DEBUG_BIT_TUNE,
 			dsyslog("Mcli::%s: Releasing tuner on device %d (%s)\n", __FUNCTION__, CardIndex()+1, m_chan.Name());
+			)
 #endif			
 			m_mcli->TunerFree(m_tunerref, false);
 			m_tunerref = NULL;
@@ -314,7 +318,9 @@ bool cMcliDevice::ProvidesSource (int Source) const
 		}
 	} 
 #ifdef DEBUG_TUNE_EXTRA
+	DEBUG_MASK(DEBUG_BIT_TUNE-EXTRA,
 	dsyslog ("Mcli::%s: DVB:%d Type:%d Pos:%d -> %d\n", __FUNCTION__, CardIndex () + 1, type, pos, ret);
+	)
 #endif
 	return ret;
 }
@@ -366,7 +372,9 @@ bool cMcliDevice::ProvidesTransponder (const cChannel * Channel) const
 	}
 
 #ifdef DEBUG_TUNE_EXTRA
+	DEBUG_MASK(DEBUG_BIT_TUNE_EXTRA,
 	dsyslog ("Mcli::%s: DVB:%d S2:%d %s@%p -> %d\n", __FUNCTION__, CardIndex () + 1, s2, Channel->Name (), this, ret);
+	)
 #endif
 	return ret;
 }
@@ -428,38 +436,70 @@ bool cMcliDevice::ProvidesChannel (const cChannel * Channel, int Priority, bool 
 	}
 	if(!CheckCAM(Channel, false)) {
 #ifdef DEBUG_TUNE
-		dsyslog ("Mcli::%s: DVB:%d Channel(%p):%s, Prio:%d this->Prio:%d m_chan.Name:%s -> %d\n", __FUNCTION__, CardIndex () + 1, Channel, Channel->Name (), Priority, this->Priority (), m_chan.Name(), false);
+		DEBUG_MASK(DEBUG_BIT_TUNE,
+		dsyslog ("Mcli::%s: DVB:%d Channel:%s, Prio:%d this->Prio:%d m_chan.Name:%s -> %d\n", __FUNCTION__, CardIndex () + 1, Channel->Name (), Priority, this->Priority (), m_chan.Name(), false);
+		)
 #endif
 		return false;
 	}
 	if(ProvidesTransponder(Channel)) {
-		//printf ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel(%p):%s * 'ProvidesTransponder(Channel)' is True\n", CardIndex () + 1, Channel, Channel->Name ());
+#ifdef DEBUG_TUNE
+		DEBUG_MASK(DEBUG_BIT_TUNE_PC,
+		dsyslog ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel:%s * 'ProvidesTransponder(Channel)' is True\n", CardIndex () + 1, Channel->Name ());
+		)
+#endif
 		result = hasPriority;
 
-		//printf ("Mcli::ProvidesChannel: DEBUG result %d hasPriority %d\n", result, hasPriority);
+#ifdef DEBUG_TUNE
+		DEBUG_MASK(DEBUG_BIT_TUNE_PC,
+		dsyslog ("Mcli::ProvidesChannel: DEBUG result %d hasPriority %d\n", result, hasPriority);
+		)
+#endif
 
 		if (Priority >= 0 && Receiving (true))
 		{
-	                //printf ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel(%p):%s * 'Priority >= 0 && Receiving (true)' is True\n", CardIndex () + 1, Channel, Channel->Name ());
+#ifdef DEBUG_TUNE
+			DEBUG_MASK(DEBUG_BIT_TUNE_PC,
+	                dsyslog ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel:%s * 'Priority >= 0 && Receiving (true)' is True\n", CardIndex () + 1, Channel->Name ());
+			)
+#endif
 
 			if (!IsTunedToTransponder(Channel)) {
 				needsDetachReceivers = true;
-	                        //printf ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel(%p):%s * '!IsTunedToTransponder(Channel)' is True\n", CardIndex () + 1, Channel, Channel->Name ());
+#ifdef DEBUG_TUNE
+				DEBUG_MASK(DEBUG_BIT_TUNE_PC,
+	                        dsyslog ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel:%s * '!IsTunedToTransponder(Channel)' is True\n", CardIndex () + 1, Channel->Name ());
+				)
+#endif
 
 			} else {
 				result = true;
-                                //printf ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel(%p):%s * '!IsTunedToTransponder(Channel)' is False * result = true ***** OK\n", CardIndex () + 1, Channel, Channel->Name ());
+#ifdef DEBUG_TUNE
+				DEBUG_MASK(DEBUG_BIT_TUNE_PC,
+                                dsyslog ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel:%s * '!IsTunedToTransponder(Channel)' is False * result = true ***** OK\n", CardIndex () + 1, Channel->Name ());
+				)
+#endif
 			}
 
 		} else {
-                        //printf ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel(%p):%s * 'Priority >= 0 && Receiving (true)' is False\n", CardIndex () + 1, Channel, Channel->Name ());
+#ifdef DEBUG_TUNE
+			DEBUG_MASK(DEBUG_BIT_TUNE_PC,
+                        dsyslog ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel:%s * 'Priority >= 0 && Receiving (true)' is False\n", CardIndex () + 1, Channel->Name ());
+			)
+#endif
 		}
 	} else {
-                //printf ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel(%p):%s * 'ProvidesTransponder(Channel)' is False\n", CardIndex () + 1, Channel, Channel->Name ());
+#ifdef DEBUG_TUNE
+		DEBUG_MASK(DEBUG_BIT_TUNE_PC,
+                dsyslog ("Mcli::ProvidesChannel: DEBUG DVB:%d Channel:%s * 'ProvidesTransponder(Channel)' is False\n", CardIndex () + 1, Channel->Name ());
+		)
+#endif
 	}
 
 #ifdef DEBUG_TUNE
-	dsyslog ("Mcli::%s: DVB:%d Channel(%p):%s, Prio:%d this->Prio:%d m_chan.Name:%s NeedsDetachReceivers:%d -> %d\n", __FUNCTION__, CardIndex () + 1, Channel, Channel->Name (), Priority, this->Priority (), m_chan.Name(), needsDetachReceivers, result);
+	DEBUG_MASK(DEBUG_BIT_TUNE,
+	dsyslog ("Mcli::%s: DVB:%d Channel:%s, Prio:%d this->Prio:%d NeedsDetachReceivers:%d -> %d\n", __FUNCTION__, CardIndex () + 1, Channel->Name (), Priority, this->Priority (), needsDetachReceivers, result);
+	)
 #endif
 	if (NeedsDetachReceivers) {
 		*NeedsDetachReceivers = needsDetachReceivers;
@@ -528,7 +568,9 @@ bool cMcliDevice::SetChannelDevice (const cChannel * Channel, bool LiveView)
 	is_scan = !strlen(Channel->Name()) && !strlen(Channel->Provider());
 	
 #ifdef DEBUG_TUNE
-	dsyslog ("Mcli::%s: DVB:%d Channel(%p):%s, Provider:%s, Source:%d, LiveView:%s, IsScan:%d, m_chan.Name:%s", __FUNCTION__, CardIndex () + 1, Channel, Channel->Name (), Channel->Provider (), Channel->Source (), LiveView ? "true" : "false", is_scan, m_chan.Name());
+	DEBUG_MASK(DEBUG_BIT_TUNE,
+	dsyslog ("Mcli::%s: Request tuning on DVB:%d to Channel:%s, Provider:%s, Source:%d, LiveView:%s, IsScan:%d", __FUNCTION__, CardIndex () + 1, Channel->Name (), Channel->Provider (), Channel->Source (), LiveView ? "true" : "false", is_scan);
+	)
 #endif
 	if (!m_enable) {
 		return false;
@@ -545,8 +587,10 @@ bool cMcliDevice::SetChannelDevice (const cChannel * Channel, bool LiveView)
 	bool cam_force = m_mcli && m_mcli->CAMPresent() && LiveView;
 	if(cam_force && !CheckCAM(Channel, true)) {
 #ifdef DEBUG_TUNE
+		DEBUG_MASK(DEBUG_BIT_TUNE,
 		dsyslog("Mcli::%s: No CAM on DVB %d available even after tried to steal one", __FUNCTION__, CardIndex () + 1);
 		dsyslog("Mcli::%s: CAMPresent: %d", __FUNCTION__, m_mcli->CAMPresent());
+		)
 #endif
 		return false;
 	}
@@ -560,12 +604,19 @@ bool cMcliDevice::SetChannelDevice (const cChannel * Channel, bool LiveView)
 			}
 		}
 		if(!(m_camref=m_mcli->CAMAlloc(NULL, slot))) {
+			if(cam_force || m_cam_disable) {
 #ifdef DEBUG_TUNE
-			dsyslog("Mcli::%s: failed to get CAM on DVB %d\n", __FUNCTION__, CardIndex () + 1);
+				DEBUG_MASK(DEBUG_BIT_TUNE,
+				dsyslog("Mcli::%s: CAM required, cannot tune on DVB %d (cam_force=%s, m_cam_disable=%s)\n", __FUNCTION__, CardIndex () + 1, cam_force ? "true" : "false", m_cam_disable ? "true" : "false");
 #endif
-			if(cam_force) {
-				return false;
+				)
+				return scrNotAvailable;
 			}
+#ifdef DEBUG_TUNE
+			DEBUG_MASK(DEBUG_BIT_TUNE,
+			dsyslog("Mcli::%s: failed to get CAM on DVB %d (cam_force=%s m_cam_disable=%s)\n", __FUNCTION__, CardIndex () + 1, cam_force ? "true" : "false", m_cam_disable ? "true" : "false");
+			)
+#endif
 		}
 		if(m_camref) {
 			SetCaEnable();
@@ -622,7 +673,9 @@ bool cMcliDevice::SetChannelDevice (const cChannel * Channel, bool LiveView)
 		m_chan = *Channel;
 
 #ifdef DEBUG_TUNE
+		DEBUG_MASK(DEBUG_BIT_TUNE,
                 dsyslog("Mcli::%s: Already tuned to transponder on DVB %d", __FUNCTION__, CardIndex () + 1);
+		)
 #endif
 		return true;
 	} else {
@@ -633,7 +686,9 @@ bool cMcliDevice::SetChannelDevice (const cChannel * Channel, bool LiveView)
 	m_chan = *Channel;
 
 #ifdef DEBUG_TUNE
-	dsyslog("Mcli::%s: Really tuning on %d", __FUNCTION__, CardIndex () + 1);
+	DEBUG_MASK(DEBUG_BIT_TUNE,
+	dsyslog ("Mcli::%s: Really tuning now DVB:%d to Channel:%s, Provider:%s, Source:%d, LiveView:%s, IsScan:%d", __FUNCTION__, CardIndex () + 1, Channel->Name (), Channel->Provider (), Channel->Source (), LiveView ? "true" : "false", is_scan);
+	)
 #endif
 	switch (m_fetype) {
 	case FE_DVBS2:
@@ -788,7 +843,9 @@ bool cMcliDevice::HasLock (int TimeoutMs) const
 bool cMcliDevice::SetPid (cPidHandle * Handle, int Type, bool On)
 {
 #ifdef DEBUG_TUNE
+	DEBUG_MASK(DEBUG_BIT_TUNE,
 	dsyslog ("Mcli::%s: DVB:%d Pid:%d (%s), Type:%d, On:%d, used:%d sid:%d ca_enable:%d channel_ca:%d\n", __FUNCTION__, CardIndex () + 1, Handle->pid, m_chan.Name(), Type, On, Handle->used, m_chan.Sid(), GetCaEnable(), m_chan.Ca (0));
+	)
 #endif
 	dvb_pid_t pi;
 	memset (&pi, 0, sizeof (dvb_pid_t));
@@ -1031,14 +1088,14 @@ int cMcliDevice::SignalQuality(void) const
 const cChannel *cMcliDevice::GetCurrentlyTunedTransponder(void) const
 {
 	if (!m_enable) {
-		dsyslog("Mcli::%s: m_fetype=%d not enabled", __FUNCTION__, m_fetype);
+		dsyslog("Mcli::%s: DVB:%d m_fetype=%d not enabled", __FUNCTION__, CardIndex () + 1, m_fetype);
 		return NULL;
 	};
 	if (!m_tuned) {
-		dsyslog("Mcli::%s: m_fetype=%d not tuned", __FUNCTION__, m_fetype);
+		dsyslog("Mcli::%s: DVB:%d m_fetype=%d not tuned", __FUNCTION__, CardIndex () + 1, m_fetype);
 		return NULL;
 	};
-	dsyslog("Mcli::%s: m_chan.Name='%s', m_chan.Number=%d m_fetype=%d", __FUNCTION__, m_chan.Name(), m_chan.Number(), m_fetype);
+	dsyslog("Mcli::%s: DVB:%d m_chan.Name='%s', m_chan.Number=%d m_fetype=%d", __FUNCTION__, CardIndex () + 1, m_chan.Name(), m_chan.Number(), m_fetype);
 	return &m_chan;
 }
 #endif

--- a/filter.c
+++ b/filter.c
@@ -161,7 +161,9 @@ bool cMcliFilter::PutSection (const uchar * Data, int Length, bool Pusi)
 
 		if (m_Used > length) {
 #ifdef DEBUG_FILTER
+			DEBUG_MASK(DEBUG_BIT_FILTER,
 			dsyslog ("cMcliFilter::PutSection: m_Used > length !  Pid %2d, Tid%2d " "(len %3d, got %d/%d)", m_Pid, m_Tid, Length, m_Used, length);
+			)
 #endif
 			if (Length < TS_SIZE - 5) {
 				// TS packet not full -> this must be last TS packet of section data -> safe to reset now
@@ -175,8 +177,10 @@ bool cMcliFilter::PutSection (const uchar * Data, int Length, bool Pusi)
 void cMcliFilter::Reset (void)
 {
 #ifdef DEBUG_FILTER
+	DEBUG_MASK(DEBUG_BIT_FILTER,
 	if (m_Used)
 		dsyslog ("cMcliFilter::Reset skipping %d bytes", m_Used);
+	)
 #endif		
 	m_Used = 0;
 }
@@ -292,7 +296,9 @@ int cMcliPidList::GetTidFromPid (int pid)
 	for (cMcliPid * p = First (); p; p = Next (p)) {
 		if (p->Pid () == pid) {
 #ifdef DEBUG_PIDS
+			DEBUG_MASK(DEBUG_BIT_PIDS,
 			dsyslog("Mcli::%s: Found pid %d -> tid %d", __FUNCTION__, pid, p->Tid());
+			)
 #endif
 			return p->Tid ();
 		}
@@ -306,7 +312,9 @@ void cMcliPidList::SetPid (int Pid, int Tid)
 		for (cMcliPid * p = First (); p; p = Next (p)) {
 			if (p->Pid () == Pid) {
 #ifdef DEBUG_PIDS
+				DEBUG_MASK(DEBUG_BIT_PIDS,
 				dsyslog("Mcli::%s: Change pid %d -> tid %d", __FUNCTION__, Pid, Tid);
+				)
 #endif
 				if (Tid != 0xffff) {
 					p->SetTid (Tid);
@@ -317,13 +325,17 @@ void cMcliPidList::SetPid (int Pid, int Tid)
 		cMcliPid *pid = new cMcliPid (Pid, Tid);
 		Add (pid);
 #ifdef DEBUG_PIDS
+		DEBUG_MASK(DEBUG_BIT_PIDS,
 		dsyslog("Mcli::%s: Add pid %d -> tid %d", __FUNCTION__, Pid, Tid);
+		)
 #endif
 	} else {
 		for (cMcliPid * p = First (); p; p = Next (p)) {
 			if (p->Pid () == Pid) {
 #ifdef DEBUG_PIDS
+				DEBUG_MASK(DEBUG_BIT_PIDS,
 				dsyslog("Mcli::%s: Del pid %d", __FUNCTION__, Pid);
+				)
 #endif
 				Del (p);
 				return;
@@ -443,7 +455,9 @@ void cMcliFilters::Action (void)
 	}
 	DELETENULL (m_PB);
 #ifdef DEBUG_FILTER
+	DEBUG_MASK(DEBUG_BIT_FILTER,
 	dsyslog ("McliFilters::Action() ended");
+	)
 #endif
 }
 

--- a/mcast/client/recv_tv.c
+++ b/mcast/client/recv_tv.c
@@ -111,7 +111,7 @@ static void *recv_ts (void *arg)
 				int transport_error_indicator = ts[1]&0x80;
 	
 				if (pid != 8191 && (adaption_field & 1) && (((cont_old + 1) & 0xf) != cont) && cont_old >= 0) {
-					warn ("Mcli::%s: Discontinuity on receiver %p for pid %d: %d->%d at pos %d/%d\n", __FUNCTION__, r, pid, cont_old, cont, i, n / 188);
+					warn ("Mcli::%s: Discontinuity on receiver for Pid:%d %d->%d at pos %d/%d\n", __FUNCTION__, pid, cont_old, cont, i, n / 188);
  				}
 				if (transport_error_indicator) {
 					warn ("Mcli::%s: Transport error indicator set on receiver %p for pid %d: %d->%d at pos %d/%d\n", __FUNCTION__, r, pid, cont_old, cont, i, n / 188);

--- a/mcli.h
+++ b/mcli.h
@@ -16,8 +16,8 @@
 #include "device.h"
 #include "cam_menu.h"
 
-#define MCLI_DEVICE_VERSION "0.9.4.1"
-#define MCLI_PLUGIN_VERSION "0.9.4.1"
+#define MCLI_DEVICE_VERSION "0.9.5"
+#define MCLI_PLUGIN_VERSION "0.9.5"
 #define MCLI_PLUGIN_DESCRIPTION trNOOP ("NetCeiver Client Application")
 #define MCLI_SETUPMENU_DESCRIPTION trNOOP ("NetCeiver Client Application")
 #define MCLI_MAINMENU_DESCRIPTION trNOOP ("Common Interface")

--- a/mcli.h
+++ b/mcli.h
@@ -35,18 +35,20 @@
 #define LASTSEEN_TIMEOUT (10)
 //#define ENABLE_DEVICE_PRIORITY
 
-//#define DEBUG_PIDS 
-//#define DEBUG_TUNE_EXTRA
+#define DEBUG_PIDS
+#define DEBUG_TUNE_EXTRA
 #define DEBUG_TUNE
-//#define DEBUG_RESOURCES
+#define DEBUG_RESOURCES
+#define DEBUG_FILTER
 
-#define DEBUG_BIT_PIDS 	0x01
+#define DEBUG_BIT_PIDS	 	0x01
 #define DEBUG_BIT_TUNE_EXTRA	0x02
 #define DEBUG_BIT_TUNE		0x04
 #define DEBUG_BIT_RESOURCES	0x08
+#define DEBUG_BIT_FILTER	0x10
 #define DEBUG_BIT_TUNE_PC	0x40	// ProvideChannel
 
-#define DEBUG_MASK(bit, code)	if ((m_debugmask && bit) != 0) { code };
+#define DEBUG_MASK(bit, code)	if ((m_debugmask & bit) != 0) { code };
 
 extern int m_debugmask;
 extern bool m_cam_disable;

--- a/mcli.h
+++ b/mcli.h
@@ -16,8 +16,8 @@
 #include "device.h"
 #include "cam_menu.h"
 
-#define MCLI_DEVICE_VERSION "0.9.4"
-#define MCLI_PLUGIN_VERSION "0.9.4"
+#define MCLI_DEVICE_VERSION "0.9.4.1"
+#define MCLI_PLUGIN_VERSION "0.9.4.1"
 #define MCLI_PLUGIN_DESCRIPTION trNOOP ("NetCeiver Client Application")
 #define MCLI_SETUPMENU_DESCRIPTION trNOOP ("NetCeiver Client Application")
 #define MCLI_MAINMENU_DESCRIPTION trNOOP ("Common Interface")
@@ -37,8 +37,19 @@
 
 //#define DEBUG_PIDS 
 //#define DEBUG_TUNE_EXTRA
-//#define DEBUG_TUNE
+#define DEBUG_TUNE
 //#define DEBUG_RESOURCES
+
+#define DEBUG_BIT_PIDS 	0x01
+#define DEBUG_BIT_TUNE_EXTRA	0x02
+#define DEBUG_BIT_TUNE		0x04
+#define DEBUG_BIT_RESOURCES	0x08
+#define DEBUG_BIT_TUNE_PC	0x40	// ProvideChannel
+
+#define DEBUG_MASK(bit, code)	if ((m_debugmask && bit) != 0) { code };
+
+extern int m_debugmask;
+extern bool m_cam_disable;
 
 class cMcliDeviceObject:public cListObject
 {

--- a/mcli.h
+++ b/mcli.h
@@ -40,13 +40,15 @@
 #define DEBUG_TUNE
 #define DEBUG_RESOURCES
 #define DEBUG_FILTER
+#define DEBUG_PIDS_ADD_DEL
 
 #define DEBUG_BIT_PIDS	 	0x01
 #define DEBUG_BIT_TUNE_EXTRA	0x02
 #define DEBUG_BIT_TUNE		0x04
 #define DEBUG_BIT_RESOURCES	0x08
-#define DEBUG_BIT_FILTER	0x10
+#define DEBUG_BIT_PIDS_ADD_DEL 	0x10
 #define DEBUG_BIT_TUNE_PC	0x40	// ProvideChannel
+#define DEBUG_BIT_FILTER	0x80
 
 #define DEBUG_MASK(bit, code)	if ((m_debugmask & bit) != 0) { code };
 


### PR DESCRIPTION
- cMcliDevice::SetPid: LOCK_THREAD deactivated because resulting in deadlock with osdteletext and zapping
- honor cam-disable earlier in cMcliDevice::SetChannelDevice
- add debug mask option (--debug-mask) (see mcli.h)
- fix a bunch of debug messages and turn them to be controllable by --debug-mask
- add cam-disable mode which avoid tuning to channel which requires CAM in case CAMs are generally not in use in the system (--cam-disable)
