### PR TITLE
Fix sscanf usage and let make clean remove all build files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ dist: clean
 	@echo Distribution package created as $(PACKAGE).tgz
 
 clean:
-	@-rm -f $(OBJS) $(DEPFILE) *.so *.tgz core* *~  po/*.mo po/*.pot
+	@-rm -f $(OBJS) $(DEPFILE) *.so *.tgz core* *~  po/*.mo po/*.pot .dependencies
 	$(MAKE) -C mcast/client/ clean
 	$(MAKE) -C mcast/netcv2dvbip/ clean
 	$(MAKE) -C mcast/tool/ clean

--- a/mcast/client/Makefile
+++ b/mcast/client/Makefile
@@ -190,7 +190,7 @@ depend: .dependencies
 	#makedepend -Y -- $(CFLAGS)  -- *c >/dev/null 2>&1
 
 clean:
-	rm -f $(MCLI) $(MCLI)-* *.elf *.gdb *.o *.lo *.la *~ *.so *.a *.def *.dll *.dylib out.ts
+	rm -f $(MCLI) $(MCLI)-* *.elf *.gdb *.o *.lo *.la *~ *.so *.a *.def *.dll *.dylib out.ts .dependencies
 
 mingw32:
 	rm -rf mingw/*.c mingw/*.h mingw/win32

--- a/mcast/netcv2dvbip/parse.c
+++ b/mcast/netcv2dvbip/parse.c
@@ -348,8 +348,8 @@ int ParseLine (const char *s, channel_t * ch)
 		char *caidbuf = NULL;
 		int fields;
 #if ! (defined WIN32 || defined APPLE)
-		fields = sscanf (s, "%a[^:]:%d :%a[^:]:%a[^:] :%d :%a[^:]:"
-			"%a[^:]:%d :%a[^:]:%d :%d :%d :%d ", &namebuf, 
+		fields = sscanf (s, "%m[^:]:%d :%a[^:]:%a[^:] :%d :%m[^:]:"
+			"%m[^:]:%d :%m[^:]:%d :%d :%d :%d ", &namebuf, 
 			&ch->frequency, &parambuf, &sourcebuf, &ch->srate, 
 			&vpidbuf, &apidbuf, &ch->tpid, &caidbuf, &ch->sid, 
 			&ch->nid, &ch->tid, &ch->rid);

--- a/mcast/tool/Makefile
+++ b/mcast/tool/Makefile
@@ -125,7 +125,7 @@ depend: .dependencies
 	#makedepend -Y -- $(CFLAGS)  -- *c >/dev/null 2>&1
 
 clean:
-	rm -f $(NETCVDIAG) $(NETCVUPDATE) $(NETCVLOGVIEW) *.elf *.gdb *.o *~
+	rm -f $(NETCVDIAG) $(NETCVUPDATE) $(NETCVLOGVIEW) *.elf *.gdb *.o *~ .dependencies
 
 %.o: %.c
 	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -o $@ $<


### PR DESCRIPTION
Hello,
these are the remaining bits from the patches in the old yavdr vdr-plugin-mcli package that seem to be missing from your fork.