### PR TITLE
ignore Unlock VDRVERSNUM >= 20300 

### DIFF
--- a/filter.c
+++ b/filter.c
@@ -286,7 +286,9 @@ int cMcliFilters::OpenFilter (u_short Pid, u_char Tid, u_char Mask)
 	LOCK_THREAD;
 #endif
 	Add (f);
+#if VDRVERSNUM < 20300
 	Unlock ();
+#endif
 
 	return fh;
 }


### PR DESCRIPTION
(as Lock was already replaced by LOCK_TREAD)