### PR TITLE
Fix the initialization of the cDevice instances

### DIFF
--- a/mcli.c
+++ b/mcli.c
@@ -1068,7 +1068,7 @@ bool cPluginMcli::Initialize (void)
 		return false;
 	};
 
-	bool ret = InitMcli();
+	ret = InitMcli();
 	if (!ret) {
 		esyslog ("mcli::%s: InitMcli failed", __FUNCTION__);
 		return false;

--- a/mcli.c
+++ b/mcli.c
@@ -1067,6 +1067,13 @@ bool cPluginMcli::Initialize (void)
 		esyslog ("mcli::%s: PreInitMcli failed", __FUNCTION__);
 		return false;
 	};
+
+	bool ret = InitMcli();
+	if (!ret) {
+		esyslog ("mcli::%s: InitMcli failed", __FUNCTION__);
+		return false;
+	};
+
 	dsyslog ("mcli::%s: successful", __FUNCTION__);
 	return true;
 }
@@ -1075,14 +1082,6 @@ bool cPluginMcli::Initialize (void)
 bool cPluginMcli::Start (void)
 {
 	isyslog("mcli version " MCLI_PLUGIN_VERSION " started");
-#ifdef REELVDR
-	if (access("/dev/dvb/adapter0", F_OK) != 0) //TB: this line allows the client to be used with usb-sticks without conflicts
-#endif
-	bool ret = InitMcli();
-	if (!ret) {
-		esyslog ("mcli::%s: InitMcli failed", __FUNCTION__);
-		return false;
-	};
 
 	cThread::Start ();
 	// Start any background activities the plugin shall perform.


### PR DESCRIPTION
https://htmlpreview.github.io/?https://github.com/vdr-projects/vdr/blob/master/PLUGINS.html#Devices
> A plugin that adds devices to a VDR instance shall call this function from its Initialize() function

More in depth analysis: [VDR-Portal link](https://www.vdr-portal.de/forum/index.php?thread/135649-vdr-startet-mit-vdr-plugin-mcli-nicht-error-invalid-primary-device-number-1/&postID=1359180#post1359180)